### PR TITLE
feat: implement World Cup fantasy backend, sync automation, and group…

### DIFF
--- a/backend/app/api/wc/flair/route.ts
+++ b/backend/app/api/wc/flair/route.ts
@@ -1,0 +1,41 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse, NextRequest } from 'next/server';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string; 
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+export async function PATCH(request: NextRequest) {
+  try {
+    // 1. Parse the incoming request from the frontend
+    const body = await request.json();
+    const { user_id, wc_team_flair } = body;
+
+    // 2. Validate that the frontend sent the required data
+    if (!user_id || !wc_team_flair) {
+      return NextResponse.json(
+        { error: 'Missing user_id or wc_team_flair' }, 
+        { status: 400 }
+      );
+    }
+
+    // 3. Update the user_profiles table in Supabase
+    const { data, error } = await supabase
+      .from('user_profiles')
+      .update({ wc_team_flair: wc_team_flair })
+      .eq('id', user_id) // Make sure we only update this specific user
+      .select();
+
+    if (error) throw error;
+
+    // 4. Return the updated profile data to confirm success
+    return NextResponse.json({ success: true, profile: data[0] });
+
+  } catch (error) {
+    console.error("Flair Update Error:", error);
+    return NextResponse.json(
+      { error: "Failed to update World Cup flair" }, 
+      { status: 500 }
+    );
+  }
+}

--- a/backend/app/api/wc/leaderboard/route.ts
+++ b/backend/app/api/wc/leaderboard/route.ts
@@ -1,0 +1,27 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse } from 'next/server';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export async function GET() {
+  try {
+    // This query pulls the fantasy points and joins it with the user's profile info
+    const { data, error } = await supabase
+      .from('wc_leaderboard')
+      .select(`
+        points,
+        updated_at,
+        user_profiles ( nickname, real_name, wc_team_flair )
+      `)
+      .order('points', { ascending: false }); // Highest scores at the top
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error("Leaderboard Error:", error);
+    return NextResponse.json({ error: "Failed to fetch leaderboard" }, { status: 500 });
+  }
+}

--- a/backend/app/api/wc/matches/route.ts
+++ b/backend/app/api/wc/matches/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  // Grab the key from the secure environment variables
+  const apiKey = process.env.API_FOOTBALL_KEY;
+  
+  // To get World Cup matches, you'll first need to find the specific league_id for the World Cup.
+  // For this test, let's look at a date range when the 2026 World Cup kicks off.
+  const fromDate = '2026-06-11'; 
+  const toDate = '2026-06-15';
+  
+  // Construct the URL exactly as apifootball.com expects it
+const url = `https://apiv3.apifootball.com/?action=get_events&from=${fromDate}&to=${toDate}&league_id=28&APIkey=${apiKey}`;
+
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+    
+    // Return the JSON data to your frontend
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching match data:", error);
+    return NextResponse.json({ error: "Failed to fetch matches" }, { status: 500 });
+  }
+}

--- a/backend/app/api/wc/predictions/awards/route.ts
+++ b/backend/app/api/wc/predictions/awards/route.ts
@@ -1,0 +1,66 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse, NextRequest } from 'next/server';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string; 
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+// GET: Retrieve a user's award predictions
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get('user_id');
+
+    if (!userId) {
+      return NextResponse.json({ error: "Missing user_id parameter" }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('wc_award_predictions')
+      .select('*')
+      .eq('user_id', userId)
+      .single(); // We use .single() because there is only one row per user
+
+    // PGRST116 means no rows were found (the user hasn't predicted yet), which is completely fine
+    if (error && error.code !== 'PGRST116') throw error;
+
+    return NextResponse.json({ success: true, data: data || null });
+  } catch (error) {
+    console.error("Fetch Awards Error:", error);
+    return NextResponse.json({ error: "Failed to fetch award predictions" }, { status: 500 });
+  }
+}
+
+// POST: Save or update a user's award predictions
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { user_id, golden_boot_id, golden_ball_id, golden_glove_id } = body;
+
+    if (!user_id) {
+       return NextResponse.json({ error: 'Missing user_id' }, { status: 400 });
+    }
+
+    // Upsert the prediction (inserts if new, updates if it already exists)
+    const { data, error } = await supabase
+      .from('wc_award_predictions')
+      .upsert({
+        user_id,
+        golden_boot_id: golden_boot_id || null,
+        golden_ball_id: golden_ball_id || null,
+        golden_glove_id: golden_glove_id || null,
+        updated_at: new Date().toISOString()
+      }, {
+        onConflict: 'user_id' // Uses the primary key to find existing rows
+      })
+      .select();
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, data: data[0] });
+
+  } catch (error) {
+    console.error("Award Prediction Error:", error);
+    return NextResponse.json({ error: "Failed to save award predictions" }, { status: 500 });
+  }
+}

--- a/backend/app/api/wc/predictions/groups/route.ts
+++ b/backend/app/api/wc/predictions/groups/route.ts
@@ -1,0 +1,70 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse, NextRequest } from 'next/server';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string; 
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { user_id, predictions } = body;
+
+    // predictions should be an array of objects from the frontend
+    if (!user_id || !Array.isArray(predictions) || predictions.length === 0) {
+       return NextResponse.json({ error: 'Invalid payload data' }, { status: 400 });
+    }
+
+    // Format the data to match our new schema
+    const formattedPredictions = predictions.map((pred: any) => ({
+      user_id,
+      group_name: pred.group_name,
+      predicted_1st_place: pred.first_place_id,
+      predicted_2nd_place: pred.second_place_id,
+      predicted_3rd_place: pred.third_place_id,
+      predicted_4th_place: pred.fourth_place_id,
+      updated_at: new Date().toISOString()
+    }));
+
+    // Upsert the entire array into Supabase at once
+    const { data, error } = await supabase
+      .from('wc_group_predictions')
+      .upsert(formattedPredictions, {
+        onConflict: 'user_id, group_name' 
+      })
+      .select();
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, saved_count: data.length });
+
+  } catch (error) {
+    console.error("Group Prediction Error:", error);
+    return NextResponse.json({ error: "Failed to save group predictions" }, { status: 500 });
+  }
+}
+
+
+export async function GET(request: NextRequest) {
+  try {
+    // Grab the user_id from the URL query (e.g., /api/wc/predictions/groups?user_id=123)
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get('user_id');
+
+    if (!userId) {
+      return NextResponse.json({ error: "Missing user_id parameter" }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('wc_group_predictions')
+      .select('*')
+      .eq('user_id', userId);
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error("Fetch Predictions Error:", error);
+    return NextResponse.json({ error: "Failed to fetch predictions" }, { status: 500 });
+  }
+}

--- a/backend/app/api/wc/sync/groups/route.ts
+++ b/backend/app/api/wc/sync/groups/route.ts
@@ -1,0 +1,50 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse, NextRequest } from 'next/server';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string; 
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env.API_FOOTBALL_KEY as string;
+  // The get_standings action returns the groups for the World Cup
+  const url = `https://apiv3.apifootball.com/?action=get_standings&league_id=28&APIkey=${apiKey}`;
+
+  try {
+    const response = await fetch(url);
+    const standings = await response.json();
+
+    if (!Array.isArray(standings)) {
+      throw new Error("API did not return a valid array");
+    }
+
+    // NEW: Filter the array to ONLY include actual groups (ignoring the 3rd place rankings)
+    const validGroupsOnly = standings.filter((teamData: any) => 
+      teamData.league_round && teamData.league_round.startsWith('Group')
+    );
+
+    // Loop through the FILTERED standings
+    const updatePromises = validGroupsOnly.map((teamData: any) => {
+      const teamId = parseInt(teamData.team_id || teamData.team_key);
+      const groupName = teamData.league_round; 
+
+      return supabase
+        .from('wc_teams')
+        .update({ group_name: groupName })
+        .eq('id', teamId);
+    });
+
+    await Promise.all(updatePromises);
+
+    return NextResponse.json({ success: true, updated_groups: validGroupsOnly.length });
+    
+  } catch (error) {
+    console.error("Group Sync Error:", error);
+    return NextResponse.json({ error: "Failed to sync groups" }, { status: 500 });
+  }
+}

--- a/backend/app/api/wc/sync/matches/route.ts
+++ b/backend/app/api/wc/sync/matches/route.ts
@@ -1,0 +1,52 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse, NextRequest } from 'next/server'; // Added NextRequest
+
+// Added 'as string' to assure TypeScript these exist
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string; 
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+// Added the type to the request parameter
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env.API_FOOTBALL_KEY as string;
+  const fromDate = '2026-06-11'; 
+  const toDate = '2026-06-25'; 
+  
+  const url = `https://apiv3.apifootball.com/?action=get_events&from=${fromDate}&to=${toDate}&league_id=28&APIkey=${apiKey}`;
+
+  try {
+    const response = await fetch(url);
+    const matches = await response.json();
+
+    // Added ': any' to the match parameter
+    const formattedMatches = matches.map((match: any) => ({
+      id: parseInt(match.match_id),
+      home_team_id: parseInt(match.match_hometeam_id),
+      away_team_id: parseInt(match.match_awayteam_id),
+      home_score: match.match_hometeam_score === "" ? null : parseInt(match.match_hometeam_score),
+      away_score: match.match_awayteam_score === "" ? null : parseInt(match.match_awayteam_score),
+      status: match.match_status,
+      date: `${match.match_date}T${match.match_time}:00Z`, 
+      stage: match.stage_name,
+    }));
+
+    const { data, error } = await supabase
+      .from('wc_matches')
+      .upsert(formattedMatches)
+      .select();
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, updated: data.length });
+    
+  } catch (error) {
+    console.error("Sync Error:", error);
+    return NextResponse.json({ error: "Failed to sync matches" }, { status: 500 });
+  }
+}   

--- a/backend/app/api/wc/sync/players/route.ts
+++ b/backend/app/api/wc/sync/players/route.ts
@@ -1,0 +1,52 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse, NextRequest } from 'next/server';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string; 
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env.API_FOOTBALL_KEY as string;
+  // This endpoint returns teams AND their full player rosters
+  const url = `https://apiv3.apifootball.com/?action=get_teams&league_id=28&APIkey=${apiKey}`;
+
+  try {
+    const response = await fetch(url);
+    const teams = await response.json();
+
+    let allPlayers: any[] = [];
+
+    // Loop through every team, then loop through their players
+    teams.forEach((team: any) => {
+      if (team.players && Array.isArray(team.players)) {
+        team.players.forEach((player: any) => {
+          allPlayers.push({
+            id: parseInt(player.player_key),
+            team_id: parseInt(team.team_key), // Links to wc_teams
+            name: player.player_name,
+            position: player.player_type || 'Unknown'
+          });
+        });
+      }
+    });
+
+    // Upsert all extracted players into Supabase
+    const { data, error } = await supabase
+      .from('wc_players')
+      .upsert(allPlayers)
+      .select();
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, updated: data.length });
+    
+  } catch (error) {
+    console.error("Player Sync Error:", error);
+    return NextResponse.json({ error: "Failed to sync players" }, { status: 500 });
+  }
+}

--- a/backend/app/api/wc/sync/teams/route.ts
+++ b/backend/app/api/wc/sync/teams/route.ts
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse, NextRequest } from 'next/server';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string; 
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env.API_FOOTBALL_KEY as string;
+  // Get all teams for League 28 (World Cup)
+  const url = `https://apiv3.apifootball.com/?action=get_teams&league_id=28&APIkey=${apiKey}`;
+
+  try {
+    const response = await fetch(url);
+    const teams = await response.json();
+
+    // Map the API response to fit your wc_teams schema
+    const formattedTeams = teams.map((team: any) => ({
+      id: parseInt(team.team_key),
+      name: team.team_name,
+      logo_url: team.team_badge
+    }));
+
+    // Upsert into Supabase
+    const { data, error } = await supabase
+      .from('wc_teams')
+      .upsert(formattedTeams)
+      .select();
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, updated: data.length });
+    
+  } catch (error) {
+    console.error("Team Sync Error:", error);
+    return NextResponse.json({ error: "Failed to sync teams" }, { status: 500 });
+  }
+}

--- a/backend/app/api/wc/teams/route.ts
+++ b/backend/app/api/wc/teams/route.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse } from 'next/server';
+
+const supabaseUrl = process.env.SUPABASE_URL as string;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export async function GET() {
+  try {
+    const { data: teams, error } = await supabase
+      .from('wc_teams')
+      .select('id, name, logo_url, group_name')
+      .not('group_name', 'is', null) // Ensures we only get teams assigned to groups
+      .order('group_name', { ascending: true })
+      .order('name', { ascending: true }); // Alphabetical within each group
+
+    if (error) throw error;
+
+    return NextResponse.json({ success: true, data: teams });
+  } catch (error) {
+    console.error("Fetch Teams Error:", error);
+    return NextResponse.json({ error: "Failed to fetch teams" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
1. Database Schema (Supabase RLS Enabled)

Added wc_teams, wc_players, wc_matches, wc_group_predictions, and wc_leaderboard tables using API-Football's native integer IDs for seamless upserting.
Updated user_profiles to include a wc_team_flair column.

2. Automated Data Pipeline (Sync Routes)

GET /api/wc/sync/teams & GET /api/wc/sync/groups: Fetches and maps all 48 international teams to their respective groups (A-L).
GET /api/wc/sync/players: Populates the global roster.
GET /api/wc/sync/matches: Pulls tournament fixtures and handles live score/event updates.
Note: All sync routes are secured behind a Cron Secret Bearer token.

3. Client-Facing Endpoints
GET /api/wc/teams: Returns ordered teams (grouped A-L) for the frontend drag-and-drop UI.
POST /api/wc/predictions/groups: Handles bulk upserting of user group stage standings.
GET /api/wc/predictions/groups: Retrieves a user's existing predictions.
PATCH /api/wc/flair: Updates a user's international team flair.
GET /api/wc/leaderboard: Joins fantasy points with user profile data.